### PR TITLE
fix(cli): pin Inno Setup installer download to a GitHub release

### DIFF
--- a/clients/cli/build/innosetup/Dockerfile
+++ b/clients/cli/build/innosetup/Dockerfile
@@ -8,5 +8,9 @@ ENV WINEARCH win32
 ENV FORCE_COLOR 1
 
 # # Install Inno Setup binaries
-RUN curl -SL "http://www.jrsoftware.org/download.php/is.exe" -o is.exe
+# jrsoftware.org's old download.php shortcut no longer serves the binary
+# directly (it now returns an HTML landing page); pin to a specific release
+# from GitHub instead. Stick to the last unified (non x86/x64-split) build,
+# since WINEARCH is win32.
+RUN curl -SL "https://github.com/jrsoftware/issrc/releases/download/is-6_7_3/innosetup-6.7.3.exe" -o is.exe
 RUN xvfb-run wine is.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART


### PR DESCRIPTION
## Summary
- The CLI's Windows installer build (`build/innosetup/Dockerfile`) downloads Inno Setup via `http://www.jrsoftware.org/download.php/is.exe`. That shortcut no longer serves the binary directly -- it now returns an HTML "Downloads" landing page (confirmed by curling it: 10,478 bytes of HTML, matching the size seen in the failing CI logs). `wine` then fails trying to execute that HTML as a binary (`not supported on this system`), breaking the Windows installer step of every CLI release.
- Pins the download to a specific GitHub release (`innosetup-6.7.3.exe`) instead, scraped from the same landing page. Verified it's a real `PE32 executable ... Intel i386` binary, matching the Dockerfile's `WINEARCH win32`. Deliberately avoided the newer 7.1.0 release since Inno Setup split that into separate x86/x64 installers, which could introduce a second compatibility issue with the existing win32 wine setup.

## Test plan
- [ ] CI (`build-cli` job) passes
- [ ] After merge, verify the `release` job in `phrase-cli`'s next release run gets past the "Build client" / installer step