### PR TITLE
fix(cli): guard nil file panic in generated download commands

### DIFF
--- a/clients/cli/spec/locales_download_spec.rb
+++ b/clients/cli/spec/locales_download_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+RSpec.describe "phrase locales download" do
+  let(:token) { "test-token-locales-download" }
+  let(:project_id) { "test-project-456" }
+  let(:locale_id) { "en-US" }
+
+  before do
+    mock_clear_requests!
+  end
+
+  # The API responds with 200 and an empty body when a --tags filter
+  # matches zero translations. This used to crash the generated
+  # "locales download" command with a nil pointer dereference, because
+  # it unconditionally called Close()/Name() on the (nil) result file.
+  it "does not crash when a tag filter matches no translations" do
+    mock_set!("GET", "/projects/#{project_id}/locales/#{locale_id}/download",
+      status: 200,
+      body: "",
+      headers: { "content-type" => "application/x-properties" }
+    )
+
+    r = run_cli(
+      "locales", "download",
+      "--id", locale_id,
+      "--project_id", project_id,
+      "--file_format", "properties",
+      "--tags", "nonexistent-tag",
+      "-t", token,
+      "--host", ENV.fetch("BASE_URL")
+    )
+
+    expect(r[:stderr]).not_to include("panic")
+    expect(r[:exit_code]).to eq(0)
+    expect(r[:stdout]).to eq("")
+  end
+
+  it "still prints the downloaded content for a normal response" do
+    mock_set!("GET", "/projects/#{project_id}/locales/#{locale_id}/download",
+      status: 200,
+      body: "hello=world",
+      headers: { "content-type" => "application/x-properties" }
+    )
+
+    r = run_cli(
+      "locales", "download",
+      "--id", locale_id,
+      "--project_id", project_id,
+      "--file_format", "properties",
+      "-t", token,
+      "--host", ENV.fetch("BASE_URL")
+    )
+
+    expect(r[:exit_code]).to eq(0)
+    expect(r[:stdout]).to include("hello=world")
+  end
+end

--- a/openapi-generator/templates/cli/api.handlebars
+++ b/openapi-generator/templates/cli/api.handlebars
@@ -127,10 +127,12 @@ func init{{{nickname}}}() {
 						HandleError(castedError)
 				}
 			} else if api_response.StatusCode >= 200 && api_response.StatusCode < 300 {
-				{{#if returnType}}{{#if (eq returnType "*os.File")}}content, _ := ioutil.ReadAll(data)
-				fmt.Printf("%s", string(content))
-				data.Close()
-				os.Remove(data.Name()){{else}}jsonBuf, jsonErr := json.MarshalIndent(data, "", " ")
+				{{#if returnType}}{{#if (eq returnType "*os.File")}}if data != nil {
+					content, _ := ioutil.ReadAll(data)
+					fmt.Printf("%s", string(content))
+					data.Close()
+					os.Remove(data.Name())
+				}{{else}}jsonBuf, jsonErr := json.MarshalIndent(data, "", " ")
 				if jsonErr != nil {
 					fmt.Printf("%v\n", data)
 					HandleError(err)


### PR DESCRIPTION
## Summary

A user reported that the latest CLI release panics on `phrase locales download` when a `--tags` filter matches zero translations:

```
$ phrase locales download --id en-US --project_id ... -t ... --file_format properties --tags foo
panic: runtime error: invalid memory address or nil pointer dereference
...
github.com/phrase/phrase-cli/cmd.initLocaleDownload.func1(...)
        /go/src/github.com/phrase/phrase-cli/cmd/api_locales.go:410 +0xdef
```

This is a sibling issue to #1235 (fixed in `pull.go`), but in a different code path: the standalone, per-endpoint `phrase locales download` command generated from `openapi-generator/templates/cli/api.handlebars`.

Root cause: the API returns `200 OK` with an empty body when a filter matches no translations. The SDK's `decode()` leaves the `*os.File` result `nil` in that case with no error — a valid empty export, not a failed download. The generated command unconditionally called `data.Close()` / `data.Name()` on that nil file, causing a nil pointer dereference.

Since `cmd/api_*.go` files are generated (and gitignored — never committed), the fix has to live in the Handlebars template itself, which is shared by every generated command whose return type is `*os.File`. So this also covers other download-style endpoints beyond locale download, not just the one in the report.

## Fix

Wrap the file-handling block in `api.handlebars` with a `data != nil` guard, mirroring the same fix already applied to `copyToDestination` in `pull.go`.

## Test plan

- [x] Added `spec/locales_download_spec.rb`, an integration spec that mocks the download endpoint returning `200` with an empty body and runs the actual built `phrase-cli` binary.
- [x] Regenerated the CLI locally (`npm run generate.go && npm run generate.cli`) and confirmed the new spec **fails with the exact reported panic** against the pre-fix template, and **passes** after applying the fix.
- [x] Confirmed normal (non-empty) downloads are unaffected.
- [x] Full Ruby spec suite (38 examples) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)