### PR TITLE
docs(STRINGS-3279): document unverify_new_translations, unverify_updated_translations, unverify_on_source_changes locale fields

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -1688,6 +1688,18 @@
           "language_ai_profile": {
             "type": "string"
           },
+          "unverify_new_translations": {
+            "type": "boolean",
+            "description": "Indicates that new translations for this locale are marked as unverified. Only applies to locales using the basic verification workflow. Part of the [Advanced Workflows](https://support.phrase.com/hc/en-us/articles/5784094755484) feature."
+          },
+          "unverify_updated_translations": {
+            "type": "boolean",
+            "description": "Indicates that updated translations for this locale are marked as unverified. Only applies to locales using the basic verification workflow. Part of the [Advanced Workflows](https://support.phrase.com/hc/en-us/articles/5784094755484) feature."
+          },
+          "unverify_on_source_changes": {
+            "type": "boolean",
+            "description": "Indicates that translations for this locale are marked as unverified when the source language has been changed."
+          },
           "created_at": {
             "type": "string",
             "format": "date-time"
@@ -1724,6 +1736,9 @@
             "code": "en-GB"
           },
           "language_ai_profile": "abcd1234abcd1234abcd1234abcd1234",
+          "unverify_new_translations": false,
+          "unverify_updated_translations": false,
+          "unverify_on_source_changes": false,
           "created_at": "2015-01-28T09:52:53Z",
           "updated_at": "2015-01-28T09:52:53Z"
         }
@@ -9415,6 +9430,11 @@
                     "type": "boolean",
                     "example": null
                   },
+                  "unverify_on_source_changes": {
+                    "description": "Indicates that translations for this locale should be marked as unverified when the source language has been changed.",
+                    "type": "boolean",
+                    "example": null
+                  },
                   "autotranslate": {
                     "description": "If set, translations for this locale will be fetched automatically, right after creation.",
                     "type": "boolean",
@@ -9637,6 +9657,11 @@
                   },
                   "unverify_updated_translations": {
                     "description": "Indicates that updated translations for this locale should be marked as unverified. Part of the [Advanced Workflows](https://support.phrase.com/hc/en-us/articles/5784094755484) feature.",
+                    "type": "boolean",
+                    "example": null
+                  },
+                  "unverify_on_source_changes": {
+                    "description": "Indicates that translations for this locale should be marked as unverified when the source language has been changed.",
                     "type": "boolean",
                     "example": null
                   },

--- a/paths/locales/create.yaml
+++ b/paths/locales/create.yaml
@@ -99,6 +99,10 @@ requestBody:
             description: Indicates that updated translations for this locale should be marked as unverified. Part of the [Advanced Workflows](https://support.phrase.com/hc/en-us/articles/5784094755484) feature.
             type: boolean
             example:
+          unverify_on_source_changes:
+            description: Indicates that translations for this locale should be marked as unverified when the source language has been changed.
+            type: boolean
+            example:
           autotranslate:
             description: If set, translations for this locale will be fetched automatically, right after creation.
             type: boolean

--- a/paths/locales/update.yaml
+++ b/paths/locales/update.yaml
@@ -98,6 +98,10 @@ requestBody:
             description: Indicates that updated translations for this locale should be marked as unverified. Part of the [Advanced Workflows](https://support.phrase.com/hc/en-us/articles/5784094755484) feature.
             type: boolean
             example:
+          unverify_on_source_changes:
+            description: Indicates that translations for this locale should be marked as unverified when the source language has been changed.
+            type: boolean
+            example:
           autotranslate:
             description: If set, translations for this locale will be fetched automatically, right after creation.
             type: boolean

--- a/schemas/locale.yaml
+++ b/schemas/locale.yaml
@@ -29,6 +29,15 @@ locale:
       "$ref": "./locale_preview.yaml#/locale_preview"
     language_ai_profile:
       type: string
+    unverify_new_translations:
+      type: boolean
+      description: Indicates that new translations for this locale are marked as unverified. Only applies to locales using the basic verification workflow. Part of the [Advanced Workflows](https://support.phrase.com/hc/en-us/articles/5784094755484) feature.
+    unverify_updated_translations:
+      type: boolean
+      description: Indicates that updated translations for this locale are marked as unverified. Only applies to locales using the basic verification workflow. Part of the [Advanced Workflows](https://support.phrase.com/hc/en-us/articles/5784094755484) feature.
+    unverify_on_source_changes:
+      type: boolean
+      description: Indicates that translations for this locale are marked as unverified when the source language has been changed.
     created_at:
       type: string
       format: date-time
@@ -58,5 +67,8 @@ locale:
       name: en
       code: en-GB
     language_ai_profile: abcd1234abcd1234abcd1234abcd1234
+    unverify_new_translations: false
+    unverify_updated_translations: false
+    unverify_on_source_changes: false
     created_at: '2015-01-28T09:52:53Z'
     updated_at: '2015-01-28T09:52:53Z'


### PR DESCRIPTION
## Summary
Adds the `unverify_new_translations`, `unverify_updated_translations`, and `unverify_on_source_changes` boolean fields to the locale response schema, and adds the missing `unverify_on_source_changes` request field to the create/update locale endpoints. These fields were already returned/accepted by the API but not documented.

Related task:
- https://phrase.atlassian.net/browse/STRINGS-3279
