### PR TITLE
feat(API): document tm_ids and term_base_ids params on projects API

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -17834,6 +17834,26 @@
                     "type": "boolean",
                     "example": true
                   },
+                  "tm_ids": {
+                    "description": "List of TMS translation memory IDs, used to provide reference translations for the AI translation agent.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "abcd1234cdef1234abcd1234cdef1234"
+                    ]
+                  },
+                  "term_base_ids": {
+                    "description": "List of TMS term base IDs, used to ensure consistent terminology for the AI translation agent.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "abcd1234cdef1234abcd1234cdef1234"
+                    ]
+                  },
                   "project_image": {
                     "description": "Image to identify the project",
                     "type": "string",
@@ -18172,6 +18192,26 @@
                     "description": "(Optional) Indicates whether the project should share the account's translation memory",
                     "type": "boolean",
                     "example": true
+                  },
+                  "tm_ids": {
+                    "description": "List of TMS translation memory IDs, used to provide reference translations for the AI translation agent.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "abcd1234cdef1234abcd1234cdef1234"
+                    ]
+                  },
+                  "term_base_ids": {
+                    "description": "List of TMS term base IDs, used to ensure consistent terminology for the AI translation agent.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "abcd1234cdef1234abcd1234cdef1234"
+                    ]
                   },
                   "project_image": {
                     "description": "(Optional) Image to identify the project",

--- a/paths/projects/create.yaml
+++ b/paths/projects/create.yaml
@@ -80,6 +80,20 @@ requestBody:
             description: Indicates whether the project should share the account's translation memory
             type: boolean
             example: true
+          tm_ids:
+            description: "List of TMS translation memory IDs, used to provide reference translations for the AI translation agent."
+            type: array
+            items:
+              type: string
+            example:
+              - abcd1234cdef1234abcd1234cdef1234
+          term_base_ids:
+            description: "List of TMS term base IDs, used to ensure consistent terminology for the AI translation agent."
+            type: array
+            items:
+              type: string
+            example:
+              - abcd1234cdef1234abcd1234cdef1234
           project_image:
             description: Image to identify the project
             type: string

--- a/paths/projects/update.yaml
+++ b/paths/projects/update.yaml
@@ -84,6 +84,20 @@ requestBody:
             description: "(Optional) Indicates whether the project should share the account's translation memory"
             type: boolean
             example: true
+          tm_ids:
+            description: "List of TMS translation memory IDs, used to provide reference translations for the AI translation agent."
+            type: array
+            items:
+              type: string
+            example:
+              - abcd1234cdef1234abcd1234cdef1234
+          term_base_ids:
+            description: "List of TMS term base IDs, used to ensure consistent terminology for the AI translation agent."
+            type: array
+            items:
+              type: string
+            example:
+              - abcd1234cdef1234abcd1234cdef1234
           project_image:
             description: "(Optional) Image to identify the project"
             type: string


### PR DESCRIPTION
## What changed
Documents two new optional array params on the Projects `create` and `update` API endpoints:

- `tm_ids` — list of translation memory IDs to assign to the project.
- `term_base_ids` — list of term base IDs to assign to the project.

These correspond to the "Translation memories" and "Term bases" selectors shown in the strings-app Project Settings → AI translation agent tab, which are used (in addition to the TM/TBs automatically associated with the project) as reference material for AI translation agent requests.