### PR TITLE
docs(STRINGS-3241): Document `fallback_for_unverified_translations` project setting

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -2301,6 +2301,10 @@
                 "type": "boolean",
                 "example": false
               },
+              "fallback_for_unverified_translations": {
+                "type": "boolean",
+                "example": false
+              },
               "autocomplete_job_enabled": {
                 "type": "boolean",
                 "example": false
@@ -2348,6 +2352,7 @@
               "autotranslate_use_machine_translation": false,
               "autotranslate_use_translation_memory": true,
               "autotranslate_overwrite_unverified_translations": false,
+              "fallback_for_unverified_translations": false,
               "autocomplete_job_enabled": false,
               "default_encoding": "UTF-8",
               "cldr_version": "legacy",
@@ -17935,6 +17940,11 @@
                     "type": "boolean",
                     "example": true
                   },
+                  "fallback_for_unverified_translations": {
+                    "description": "(Optional) When enabled, translations in a non-final state are replaced by the fallback locale's translation on export, in addition to empty translations. \"Non-final\" means `unverified` in the simple workflow, and additionally `translated` (awaiting review) in the review workflow. Requires a fallback locale to be configured on the locale. This is a persistent project-level default; the `fallback_for_unverified_translations` query parameter on locale downloads overrides it for a single request only.",
+                    "type": "boolean",
+                    "example": false
+                  },
                   "autocomplete_job_enabled": {
                     "description": "(Optional) Enable autocomplete-job behavior so that newly created keys and locales are automatically added to in-progress jobs.",
                     "type": "boolean",
@@ -18258,6 +18268,11 @@
                     "description": "(Optional) Requires autotranslate_enabled to be true",
                     "type": "boolean",
                     "example": true
+                  },
+                  "fallback_for_unverified_translations": {
+                    "description": "(Optional) When enabled, translations in a non-final state are replaced by the fallback locale's translation on export, in addition to empty translations. \"Non-final\" means `unverified` in the simple workflow, and additionally `translated` (awaiting review) in the review workflow. Requires a fallback locale to be configured on the locale. This is a persistent project-level default; the `fallback_for_unverified_translations` query parameter on locale downloads overrides it for a single request only.",
+                    "type": "boolean",
+                    "example": false
                   },
                   "default_encoding": {
                     "description": "(Optional) Sets the default encoding for Uploads. If you leave it empty, we will try to guess it automatically for you when you Upload a file. You can still override this value by setting the [`file_encoding`](/en/api/strings/uploads/upload-a-new-file) parameter for Uploads.",

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -17941,7 +17941,7 @@
                     "example": true
                   },
                   "fallback_for_unverified_translations": {
-                    "description": "(Optional) When enabled, translations in a non-final state are replaced by the fallback locale's translation on export, in addition to empty translations. \"Non-final\" means `unverified` in the simple workflow, and additionally `translated` (awaiting review) in the review workflow. Requires a fallback locale to be configured on the locale. This is a persistent project-level default; the `fallback_for_unverified_translations` query parameter on locale downloads overrides it for a single request only.",
+                    "description": "(Optional) When enabled, the fallback locale's translation is used on export for unverified translations in addition to empty ones. Requires a fallback locale to be configured on the locale.",
                     "type": "boolean",
                     "example": false
                   },
@@ -18270,7 +18270,7 @@
                     "example": true
                   },
                   "fallback_for_unverified_translations": {
-                    "description": "(Optional) When enabled, translations in a non-final state are replaced by the fallback locale's translation on export, in addition to empty translations. \"Non-final\" means `unverified` in the simple workflow, and additionally `translated` (awaiting review) in the review workflow. Requires a fallback locale to be configured on the locale. This is a persistent project-level default; the `fallback_for_unverified_translations` query parameter on locale downloads overrides it for a single request only.",
+                    "description": "(Optional) When enabled, the fallback locale's translation is used on export for unverified translations in addition to empty ones. Requires a fallback locale to be configured on the locale.",
                     "type": "boolean",
                     "example": false
                   },

--- a/paths/projects/create.yaml
+++ b/paths/projects/create.yaml
@@ -161,6 +161,10 @@ requestBody:
             description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
+          fallback_for_unverified_translations:
+            description: "(Optional) When enabled, translations in a non-final state are replaced by the fallback locale's translation on export, in addition to empty translations. \"Non-final\" means `unverified` in the simple workflow, and additionally `translated` (awaiting review) in the review workflow. Requires a fallback locale to be configured on the locale. This is a persistent project-level default; the `fallback_for_unverified_translations` query parameter on locale downloads overrides it for a single request only."
+            type: boolean
+            example: false
           autocomplete_job_enabled:
             description: "(Optional) Enable autocomplete-job behavior so that newly created keys and locales are automatically added to in-progress jobs."
             type: boolean

--- a/paths/projects/create.yaml
+++ b/paths/projects/create.yaml
@@ -162,7 +162,7 @@ requestBody:
             type: boolean
             example: true
           fallback_for_unverified_translations:
-            description: "(Optional) When enabled, translations in a non-final state are replaced by the fallback locale's translation on export, in addition to empty translations. \"Non-final\" means `unverified` in the simple workflow, and additionally `translated` (awaiting review) in the review workflow. Requires a fallback locale to be configured on the locale. This is a persistent project-level default; the `fallback_for_unverified_translations` query parameter on locale downloads overrides it for a single request only."
+            description: "(Optional) When enabled, the fallback locale's translation is used on export for unverified translations in addition to empty ones. Requires a fallback locale to be configured on the locale."
             type: boolean
             example: false
           autocomplete_job_enabled:

--- a/paths/projects/update.yaml
+++ b/paths/projects/update.yaml
@@ -153,6 +153,10 @@ requestBody:
             description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
+          fallback_for_unverified_translations:
+            description: "(Optional) When enabled, translations in a non-final state are replaced by the fallback locale's translation on export, in addition to empty translations. \"Non-final\" means `unverified` in the simple workflow, and additionally `translated` (awaiting review) in the review workflow. Requires a fallback locale to be configured on the locale. This is a persistent project-level default; the `fallback_for_unverified_translations` query parameter on locale downloads overrides it for a single request only."
+            type: boolean
+            example: false
           default_encoding:
             description: "(Optional) Sets the default encoding for Uploads. If you leave it empty, we will try to guess it automatically for you when you Upload a file. You can still override this value by setting the [`file_encoding`](/en/api/strings/uploads/upload-a-new-file) parameter for Uploads."
             type: string

--- a/paths/projects/update.yaml
+++ b/paths/projects/update.yaml
@@ -154,7 +154,7 @@ requestBody:
             type: boolean
             example: true
           fallback_for_unverified_translations:
-            description: "(Optional) When enabled, translations in a non-final state are replaced by the fallback locale's translation on export, in addition to empty translations. \"Non-final\" means `unverified` in the simple workflow, and additionally `translated` (awaiting review) in the review workflow. Requires a fallback locale to be configured on the locale. This is a persistent project-level default; the `fallback_for_unverified_translations` query parameter on locale downloads overrides it for a single request only."
+            description: "(Optional) When enabled, the fallback locale's translation is used on export for unverified translations in addition to empty ones. Requires a fallback locale to be configured on the locale."
             type: boolean
             example: false
           default_encoding:

--- a/schemas/project_details.yaml
+++ b/schemas/project_details.yaml
@@ -51,6 +51,9 @@ project_details:
       autotranslate_overwrite_unverified_translations:
         type: boolean
         example: false
+      fallback_for_unverified_translations:
+        type: boolean
+        example: false
       autocomplete_job_enabled:
         type: boolean
         example: false
@@ -90,6 +93,7 @@ project_details:
       autotranslate_use_machine_translation: false
       autotranslate_use_translation_memory: true
       autotranslate_overwrite_unverified_translations: false
+      fallback_for_unverified_translations: false
       autocomplete_job_enabled: false
       default_encoding: "UTF-8"
       cldr_version: "legacy"


### PR DESCRIPTION
- [Expose project setting fallback_for_unverified_translations in API docs](https://phrase.atlassian.net/browse/STRINGS-3241)
- The `fallback_for_unverified_translations` project setting was already live and returned by the API, but customers had no way to discover or use it since it wasn't documented.
- Added it to the Create/Update Project request parameters and the Project response schema, with a description matching the behavior already documented for the equivalent locale-download query parameter.