### PR TITLE
docs(STRINGS-3041): Document supported placeholder_styles values

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -810,8 +810,8 @@
       },
       "placeholder_style": {
         "type": "string",
-        "description": "Placeholder style supported for detecting and highlighting variable placeholders in translation keys.",
-        "enum": [
+        "description": "Placeholder style supported for detecting and highlighting variable placeholders in translation keys. This list may grow over time as new styles are added.",
+        "x-extensible-enum": [
           "rails_i18n",
           "i18next_nesting",
           "gettext_python",

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -808,6 +808,32 @@
         ],
         "example": "string"
       },
+      "placeholder_style": {
+        "type": "string",
+        "description": "Placeholder style supported for detecting and highlighting variable placeholders in translation keys.",
+        "enum": [
+          "rails_i18n",
+          "i18next_nesting",
+          "gettext_python",
+          "cstyle",
+          "python_strings",
+          "dot_net",
+          "java_properties",
+          "laravel",
+          "square_brackets",
+          "single_percentage",
+          "double_percentage",
+          "emoji",
+          "dollar_style",
+          "nsis",
+          "razor",
+          "double_curly",
+          "xliffg",
+          "xliff",
+          "liquid"
+        ],
+        "example": "rails_i18n"
+      },
       "key_preview": {
         "type": "object",
         "title": "key_preview",
@@ -2320,11 +2346,11 @@
               "placeholder_styles": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/placeholder_style"
                 },
                 "example": [
-                  "angular",
-                  "iOS"
+                  "rails_i18n",
+                  "java_properties"
                 ]
               },
               "branch": {
@@ -2353,8 +2379,8 @@
               "cldr_version": "legacy",
               "job_locking_enabled": false,
               "placeholder_styles": [
-                "angular",
-                "iOS"
+                "rails_i18n",
+                "java_properties"
               ]
             }
           }
@@ -18006,11 +18032,11 @@
                     "description": "(Optional) List of placeholder styles enabled for the project.",
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/components/schemas/placeholder_style"
                     },
                     "example": [
-                      "angular",
-                      "iOS"
+                      "rails_i18n",
+                      "java_properties"
                     ]
                   }
                 }
@@ -18315,11 +18341,11 @@
                     "description": "(Optional) List of placeholder styles enabled for the project.",
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/components/schemas/placeholder_style"
                     },
                     "example": [
-                      "angular",
-                      "iOS"
+                      "rails_i18n",
+                      "java_properties"
                     ]
                   },
                   "autocomplete_job_enabled": {

--- a/paths/projects/create.yaml
+++ b/paths/projects/create.yaml
@@ -217,8 +217,8 @@ requestBody:
             description: "(Optional) List of placeholder styles enabled for the project."
             type: array
             items:
-              type: string
+              "$ref": "../../schemas/placeholder_style.yaml#/placeholder_style"
             example:
-              - "angular"
-              - "iOS"
+              - "rails_i18n"
+              - "java_properties"
 x-cli-version: "2.6.3"

--- a/paths/projects/update.yaml
+++ b/paths/projects/update.yaml
@@ -181,10 +181,10 @@ requestBody:
             description: "(Optional) List of placeholder styles enabled for the project."
             type: array
             items:
-              type: string
+              "$ref": "../../schemas/placeholder_style.yaml#/placeholder_style"
             example:
-              - "angular"
-              - "iOS"
+              - "rails_i18n"
+              - "java_properties"
           autocomplete_job_enabled:
             description: "(Optional) Enable autocomplete-job behavior so that newly created keys and locales are automatically added to in-progress jobs."
             type: boolean

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -20,6 +20,8 @@ schemas:
     "$ref": schemas/custom_metadata_property.yaml#/custom_metadata_property
   custom_metadata_data_type:
     "$ref": schemas/custom_metadata_data_type.yaml#/data_type
+  placeholder_style:
+    "$ref": schemas/placeholder_style.yaml#/placeholder_style
   key_preview:
     "$ref": schemas/key_preview.yaml#/key_preview
   affected_count:

--- a/schemas/placeholder_style.yaml
+++ b/schemas/placeholder_style.yaml
@@ -3,8 +3,9 @@ placeholder_style:
   type: string
   description: >-
     Placeholder style supported for detecting and highlighting variable
-    placeholders in translation keys.
-  enum:
+    placeholders in translation keys. This list may grow over time as new
+    styles are added.
+  x-extensible-enum:
     - rails_i18n
     - i18next_nesting
     - gettext_python

--- a/schemas/placeholder_style.yaml
+++ b/schemas/placeholder_style.yaml
@@ -1,0 +1,27 @@
+---
+placeholder_style:
+  type: string
+  description: >-
+    Placeholder style supported for detecting and highlighting variable
+    placeholders in translation keys.
+  enum:
+    - rails_i18n
+    - i18next_nesting
+    - gettext_python
+    - cstyle
+    - python_strings
+    - dot_net
+    - java_properties
+    - laravel
+    - square_brackets
+    - single_percentage
+    - double_percentage
+    - emoji
+    - dollar_style
+    - nsis
+    - razor
+    - double_curly
+    - xliffg
+    - xliff
+    - liquid
+  example: rails_i18n

--- a/schemas/project_details.yaml
+++ b/schemas/project_details.yaml
@@ -66,10 +66,10 @@ project_details:
       placeholder_styles:
         type: array
         items:
-          type: string
+          "$ref": "./placeholder_style.yaml#/placeholder_style"
         example:
-          - "angular"
-          - "iOS"
+          - "rails_i18n"
+          - "java_properties"
       branch:
         "$ref": "./branch.yaml#/branch"
 
@@ -95,5 +95,5 @@ project_details:
       cldr_version: "legacy"
       job_locking_enabled: false
       placeholder_styles:
-        - "angular"
-        - "iOS"
+        - "rails_i18n"
+        - "java_properties"


### PR DESCRIPTION
## Purpose

- The `placeholder_styles` field on projects (used when creating or updating a project, and returned in project responses) previously had no documented set of valid values, so API clients had no way to know which style keys were accepted.
- Added an enum listing the currently supported placeholder style keys directly in the schema, so this is now discoverable from the spec instead of requiring guesswork.

https://phrase.atlassian.net/browse/STRINGS-3041