### PR TITLE
feat(API): add created_since filter to check issues list #STRINGS-3043

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -23663,6 +23663,16 @@
                 "translation_placeholder_usage"
               ]
             }
+          },
+          {
+            "name": "created_since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "2026-01-01T12:00:00Z",
+            "description": "Return only check issues created on or after this ISO 8601 datetime. Returns 400 if the value is not a valid date-time."
           }
         ],
         "responses": {

--- a/paths/checks/index.yaml
+++ b/paths/checks/index.yaml
@@ -54,6 +54,13 @@ parameters:
       - translation_glossary_usage
     example:
     - translation_placeholder_usage
+- name: created_since
+  in: query
+  required: false
+  schema:
+    type: string
+  example: "2026-01-01T12:00:00Z"
+  description: Return only check issues created on or after this ISO 8601 datetime. Returns 400 if the value is not a valid date-time.
 responses:
   '200':
     description: OK


### PR DESCRIPTION
## What

Add optional `created_since` query param to `GET /api/v2/projects/{project_id}/checks/issues`. When set, only check issues with `created_at >= created_since` are returned. Invalid ISO 8601 value → `400`.

## Why

Syncs the public API contract with app PR [strings-app#18631](https://github.com/Phrase-Engineering/strings-app/pull/18631) ([STRINGS-3043](https://phrase.atlassian.net/browse/STRINGS-3043)), proposed by the `openapi-sync` bot.

## Changes

- `paths/checks/index.yaml` — new inline `created_since` query param (matches existing `automation_events` datetime-filter convention).
- `doc/compiled.json` — regenerated via `make bundle`.

Response schema unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STRINGS-3043]: https://phrase.atlassian.net/browse/STRINGS-3043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ