### PR TITLE
docs(STRINGS-3095): Warn that job tags match all keys carrying the tag

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -12129,7 +12129,7 @@
                     "example": "https://example.atlassian.net/browse/FOO"
                   },
                   "tags": {
-                    "description": "tags of keys that should be included within the job",
+                    "description": "tags of keys that should be included within the job.\n\n*Note: a tag matches every key currently carrying that tag, not just the ones you just tagged. For example, if hundreds of pre-existing keys already share the tag `myUploadTag`, adding it here pulls in every one of them, not only the key you just tagged. Use `translation_key_ids` to scope the job to specific keys instead.*\n",
                     "type": "array",
                     "items": {
                       "type": "string"

--- a/paths/jobs/create.yaml
+++ b/paths/jobs/create.yaml
@@ -85,7 +85,10 @@ requestBody:
             type: string
             example: https://example.atlassian.net/browse/FOO
           tags:
-            description: tags of keys that should be included within the job
+            description: |
+              tags of keys that should be included within the job.
+
+              *Note: a tag matches every key currently carrying that tag, not just the ones you just tagged. For example, if hundreds of pre-existing keys already share the tag `myUploadTag`, adding it here pulls in every one of them, not only the key you just tagged. Use `translation_key_ids` to scope the job to specific keys instead.*
             type: array
             items:
               type: string


### PR DESCRIPTION
**Related ticket:** https://phrase.atlassian.net/browse/STRINGS-3095

## Purpose

- The create-job `tags` field was documented without warning that a shared tag matches every key already carrying it, which let a caller unintentionally pull dozens of unrelated pre-existing keys into a job.
- Added a caution note to the field description telling callers that a tag matches all keys currently carrying it, and to use `translation_key_ids` when they need to scope a job to specific keys.
- Docs-only change; no API behavior is affected.
