### PR TITLE
docs(STRINGS-3229): document error_message field on upload response

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -2072,6 +2072,11 @@
           "state": {
             "type": "string"
           },
+          "error_message": {
+            "type": "string",
+            "nullable": true,
+            "description": "A user-facing message explaining why the upload failed, or `null` if the upload did not fail.\n\nThis message is intended for display only. Its wording may change at any time and it should not be parsed or relied upon programmatically.\n"
+          },
           "tag": {
             "type": "string",
             "description": "Unique tag of the upload\n"
@@ -2141,6 +2146,7 @@
           "filename": "example.json",
           "format": "json",
           "state": "success",
+          "error_message": null,
           "tag": "tag",
           "summary": {
             "locales_created": 2,

--- a/schemas/upload.yaml
+++ b/schemas/upload.yaml
@@ -11,6 +11,13 @@ upload:
       type: string
     state:
       type: string
+    error_message:
+      type: string
+      nullable: true
+      description: |
+        A user-facing message explaining why the upload failed, or `null` if the upload did not fail.
+
+        This message is intended for display only. Its wording may change at any time and it should not be parsed or relied upon programmatically.
     tag:
       type: string
       description: |
@@ -66,6 +73,7 @@ upload:
     filename: example.json
     format: json
     state: success
+    error_message: null
     tag: tag
     summary:
       locales_created: 2


### PR DESCRIPTION
## Purpose

- Adds an `error_message` field to the public `upload` schema so API callers can finally see why an upload failed, instead of just getting `state: "error"` with no detail.
- The field is `null` when an upload succeeds and only populated with a display message when it fails.
- This documents the schema side of [Upload error state exposes no diagnostic detail — FailedUpload message never reaches public API](https://phrase.atlassian.net/browse/STRINGS-3229).
